### PR TITLE
Add Netboot.xyz container for PXE boot

### DIFF
--- a/netboot/docker-compose.yml
+++ b/netboot/docker-compose.yml
@@ -1,0 +1,18 @@
+---
+version: "2.1"
+services:
+  netbootxyz:
+    image: ghcr.io/netbootxyz/netbootxyz
+    container_name: netbootxyz
+    environment:
+      - MENU_VERSION=2.0.47 # optional
+      - NGINX_PORT=80 # optional
+      - WEB_APP_PORT=3000 # optional
+    volumes:
+      - /opt/docker/netboot/data:/config # optional
+      - /opt/docker/netboot/data/assets:/assets # optional
+    ports:
+      - 3030:3000  # optional, destination should match ${WEB_APP_PORT} variable above.
+      - 69:69/udp
+      - 8088:80  # optional, destination should match ${NGINX_PORT} variable above.
+    restart: unless-stopped


### PR DESCRIPTION
Added basic config and setup for netboot.xyz container to enable PXE booting.  More details can be found here
https://netboot.xyz/docs/docker